### PR TITLE
added ajax refresh button automatic integration with every GridField instance

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,0 +1,13 @@
+---
+Name: gridfieldajaxrefresh
+Before: 'mysite/*'
+After: 'framework/*','cms/*'
+---
+
+GridFieldConfig_Base:
+  extensions:
+    - GridFieldAjaxRefresh_Base
+
+GridFieldConfig_RecordEditor:
+  extensions:
+    - GridFieldAjaxRefresh_RecordEditor

--- a/code/GridFieldAjaxRefresh.php
+++ b/code/GridFieldAjaxRefresh.php
@@ -9,6 +9,9 @@
 class GridFieldAjaxRefresh implements GridField_HTMLProvider
 {
 
+    private static $auto_refresh_enabled = false;
+    private static $auto_refresh_interval = 180000; // 180000 = 3 min
+
     protected $refreshDelay;    //in milliseconds: 1000 ms = 1 second
     protected $autoRefresh;
 

--- a/code/GridFieldAjaxRefreshConfig.php
+++ b/code/GridFieldAjaxRefreshConfig.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * This component provides a automatic integration of ajax refresh button with default {@link GridField}
+ *
+ * @package GridFieldAjaxRefresh
+ */
+class GridFieldAjaxRefresh_Base extends Extension {
+
+	public function updateConfig() {
+		$this->owner->addComponent(new GridFieldAjaxRefresh(5000, false));
+	}
+
+}
+
+class GridFieldAjaxRefresh_RecordEditor extends Extension {
+
+	public function updateConfig() {
+		$this->owner->addComponent(new GridFieldAjaxRefresh(5000, false));
+	}
+
+}

--- a/code/GridFieldAjaxRefreshConfig.php
+++ b/code/GridFieldAjaxRefreshConfig.php
@@ -5,18 +5,32 @@
  *
  * @package GridFieldAjaxRefresh
  */
-class GridFieldAjaxRefresh_Base extends Extension {
+class GridFieldAjaxRefresh_Base extends Extension
+{
 
-	public function updateConfig() {
-		$this->owner->addComponent(new GridFieldAjaxRefresh(5000, false));
+	public function updateConfig()
+	{
+		$this->owner->addComponent(
+			new GridFieldAjaxRefresh(
+				Config::inst()->get('GridFieldAjaxRefresh', 'auto_refresh_interval'),
+				Config::inst()->get('GridFieldAjaxRefresh', 'auto_refresh_enabled')
+			)
+		);
 	}
 
 }
 
-class GridFieldAjaxRefresh_RecordEditor extends Extension {
+class GridFieldAjaxRefresh_RecordEditor extends Extension
+{
 
-	public function updateConfig() {
-		$this->owner->addComponent(new GridFieldAjaxRefresh(5000, false));
+	public function updateConfig()
+	{
+		$this->owner->addComponent(
+			new GridFieldAjaxRefresh(
+				Config::inst()->get('GridFieldAjaxRefresh', 'auto_refresh_interval'),
+				Config::inst()->get('GridFieldAjaxRefresh', 'auto_refresh_enabled')
+			)
+		);
 	}
 
 }

--- a/css/GridFieldAjaxRefresh.css
+++ b/css/GridFieldAjaxRefresh.css
@@ -1,3 +1,4 @@
 .cms .ss-gridfield > div.auto-refresh-button {
-	margin-bottom: 12px;
+	float: left;
+	margin: 0 5px;
 }


### PR DESCRIPTION
This change make ajax refresh button available on every GridField instance by default configuration.

[NOTE] in order to use this feature you must apply patch: 
API Change: Make GridFieldConfig objects decoratable #2311 
https://github.com/silverstripe/silverstripe-framework/pull/2311
